### PR TITLE
⬆️ Migration to AndroidX & Updated Butterknife version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx5120M -XX\:MaxPermSize\=512m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8 -Dapollographql.skipRuntimeDep=true
+android.useAndroidX=true
+android.enableJetifier=true
 #compileJava.options.incremental=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,12 +1,12 @@
 def versions = [
     androidPlugin        : '3.3.0',
-    androidSupportVersion: '28.0.0',
+    androidSupportVersion: '1.0.0',
     okHttpVersion        : '3.7.0',
     playServicesVersion  : '16.0.1',
     jodaTimeVersion      : '2.9.9',
-    butterKnifeVersion   : '9.0.0',
+    butterKnifeVersion   : '10.2.1',
     apolloVersion        : '1.0.0',
-    archVersion          : '1.1.1',
+    archVersion          : '2.0.0',
     kotlin               : '1.3.30',
     buySdkVersion        : '5.0.0'
 ]
@@ -21,10 +21,10 @@ ext.androidConfig = [
 
 ext.dep = [
     androidPlugin            : "com.android.tools.build:gradle:$versions.androidPlugin",
-    androidSupportAnnotations: "com.android.support:support-annotations:$versions.androidSupportVersion",
-    androidSupportDesign     : "com.android.support:design:$versions.androidSupportVersion",
-    androidSupportV4         : "com.android.support:support-v4:$versions.androidSupportVersion",
-    androidSupportV7         : "com.android.support:appcompat-v7:$versions.androidSupportVersion",
+    androidSupportAnnotations: "androidx.annotation:annotation:$versions.androidSupportVersion",
+    androidSupportDesign     : "com.google.android.material:material:$versions.androidSupportVersion",
+    androidSupportV4         : "androidx.legacy:legacy-support-v4:$versions.androidSupportVersion",
+    androidSupportV7         : "androidx.appcompat:appcompat:$versions.androidSupportVersion",
     kotlinPlugin             : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin",
     kotlinStdLib             : "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin",
     okhttp                   : "com.squareup.okhttp3:logging-interceptor:$versions.okHttpVersion",
@@ -48,9 +48,9 @@ ext.dep = [
     apolloPlugin             : "com.apollographql.apollo:apollo-gradle-plugin:$versions.apolloVersion",
     apolloRuntime            : "com.apollographql.apollo:apollo-runtime:$versions.apolloVersion",
     apolloHttpCache          : "com.apollographql.apollo:apollo-http-cache:$versions.apolloVersion",
-    constraintLayout         : "com.android.support.constraint:constraint-layout:1.0.2",
+    constraintLayout         : "androidx.constraintlayout:constraintlayout:1.1.3",
     rxrelay                  : "com.jakewharton.rxrelay2:rxrelay:2.0.0",
-    archComponents           : "android.arch.lifecycle:extensions:$versions.archVersion",
+    archComponents           : "androidx.lifecycle:lifecycle-extensions:$versions.archVersion",
     gson                     : "com.google.code.gson:gson:2.8.6",
     buySdk                   : "com.shopify.mobilebuysdk:buy3:$versions.buySdkVersion"
 ]

--- a/sample/src/main/java/com/shopify/sample/BaseApplication.java
+++ b/sample/src/main/java/com/shopify/sample/BaseApplication.java
@@ -25,8 +25,8 @@
 package com.shopify.sample;
 
 import android.app.Application;
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.MutableLiveData;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 
 import com.facebook.cache.disk.DiskCacheConfig;
 import com.facebook.common.logging.FLog;

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/CartAddItemInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/CartAddItemInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.CartItem;
 

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/CartFetchInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/CartFetchInteractor.java
@@ -1,6 +1,6 @@
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.Cart;
 

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/CartRemoveItemInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/CartRemoveItemInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.CartItem;
 

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/CheckoutCompleteInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/CheckoutCompleteInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import com.shopify.sample.domain.model.Address;
 import com.shopify.sample.domain.model.Cart;
 import com.shopify.sample.domain.model.Payment;

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/CheckoutCreateInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/CheckoutCreateInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.Checkout;
 

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/CheckoutShippingAddressUpdateInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/CheckoutShippingAddressUpdateInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import com.shopify.sample.domain.model.Address;
 import com.shopify.sample.domain.model.Checkout;
 import io.reactivex.Single;

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/CheckoutShippingLineUpdateInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/CheckoutShippingLineUpdateInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.Checkout;
 

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/CheckoutShippingRatesInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/CheckoutShippingRatesInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.Checkout;
 

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/CollectionNextPageInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/CollectionNextPageInteractor.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.shopify.sample.domain.model.Collection;
 

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/CollectionProductNextPageInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/CollectionProductNextPageInteractor.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.shopify.sample.domain.model.Product;
 

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/ProductByIdInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/ProductByIdInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.ProductDetails;
 

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/RealCartAddItemInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/RealCartAddItemInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.CartItem;
 import com.shopify.sample.domain.repository.CartRepository;

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/RealCartFetchInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/RealCartFetchInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.Cart;
 import com.shopify.sample.domain.repository.CartRepository;

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/RealCartRemoveItemInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/RealCartRemoveItemInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.CartItem;
 import com.shopify.sample.domain.repository.CartRepository;

--- a/sample/src/main/java/com/shopify/sample/domain/interactor/ShopSettingInteractor.java
+++ b/sample/src/main/java/com/shopify/sample/domain/interactor/ShopSettingInteractor.java
@@ -1,6 +1,6 @@
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.ShopSettings;
 

--- a/sample/src/main/java/com/shopify/sample/domain/model/Address.java
+++ b/sample/src/main/java/com/shopify/sample/domain/model/Address.java
@@ -23,7 +23,7 @@
  */
 package com.shopify.sample.domain.model;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Convenient class that represents a Shopify-compliant address.

--- a/sample/src/main/java/com/shopify/sample/domain/model/Cart.java
+++ b/sample/src/main/java/com/shopify/sample/domain/model/Cart.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.model;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;

--- a/sample/src/main/java/com/shopify/sample/domain/model/CartItem.java
+++ b/sample/src/main/java/com/shopify/sample/domain/model/CartItem.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.model;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.util.List;

--- a/sample/src/main/java/com/shopify/sample/domain/model/Checkout.java
+++ b/sample/src/main/java/com/shopify/sample/domain/model/Checkout.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.model;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.util.List;

--- a/sample/src/main/java/com/shopify/sample/domain/model/Collection.java
+++ b/sample/src/main/java/com/shopify/sample/domain/model/Collection.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.model;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.List;
 

--- a/sample/src/main/java/com/shopify/sample/domain/model/Payment.java
+++ b/sample/src/main/java/com/shopify/sample/domain/model/Payment.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.model;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static com.shopify.sample.util.Util.checkNotBlank;
 

--- a/sample/src/main/java/com/shopify/sample/domain/model/Product.java
+++ b/sample/src/main/java/com/shopify/sample/domain/model/Product.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.model;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.math.BigDecimal;
 

--- a/sample/src/main/java/com/shopify/sample/domain/model/ProductDetails.java
+++ b/sample/src/main/java/com/shopify/sample/domain/model/ProductDetails.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.model;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.math.BigDecimal;
 import java.util.List;

--- a/sample/src/main/java/com/shopify/sample/domain/model/ShopSettings.java
+++ b/sample/src/main/java/com/shopify/sample/domain/model/ShopSettings.java
@@ -1,6 +1,6 @@
 package com.shopify.sample.domain.model;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import static com.shopify.sample.util.Util.checkNotNull;
 

--- a/sample/src/main/java/com/shopify/sample/domain/repository/UserError.java
+++ b/sample/src/main/java/com/shopify/sample/domain/repository/UserError.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.repository;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.List;
 

--- a/sample/src/main/java/com/shopify/sample/domain/usecases/FetchCollectionsUseCase.java
+++ b/sample/src/main/java/com/shopify/sample/domain/usecases/FetchCollectionsUseCase.java
@@ -1,7 +1,7 @@
 package com.shopify.sample.domain.usecases;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.shopify.sample.domain.model.Collection;
 import com.shopify.sample.core.UseCase;

--- a/sample/src/main/java/com/shopify/sample/domain/usecases/FetchProductsUseCase.java
+++ b/sample/src/main/java/com/shopify/sample/domain/usecases/FetchProductsUseCase.java
@@ -1,7 +1,7 @@
 package com.shopify.sample.domain.usecases;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.shopify.sample.core.UseCase.Callback1;
 import com.shopify.sample.core.UseCase.Cancelable;

--- a/sample/src/main/java/com/shopify/sample/util/FlingBehavior.java
+++ b/sample/src/main/java/com/shopify/sample/util/FlingBehavior.java
@@ -25,11 +25,11 @@
 package com.shopify.sample.util;
 
 import android.content.Context;
-import android.support.design.widget.AppBarLayout;
-import android.support.design.widget.CoordinatorLayout;
-import android.support.v4.view.ScrollingView;
-import android.support.v4.widget.SwipeRefreshLayout;
-import android.support.v7.widget.RecyclerView;
+import com.google.android.material.appbar.AppBarLayout;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.view.ScrollingView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+import androidx.recyclerview.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.View;
 

--- a/sample/src/main/java/com/shopify/sample/util/RxRetryHandler.java
+++ b/sample/src/main/java/com/shopify/sample/util/RxRetryHandler.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.util;
 
-import android.support.v4.util.Pair;
+import androidx.core.util.Pair;
 
 import java.util.concurrent.TimeUnit;
 

--- a/sample/src/main/java/com/shopify/sample/util/ScrollAwareFABBehavior.java
+++ b/sample/src/main/java/com/shopify/sample/util/ScrollAwareFABBehavior.java
@@ -24,9 +24,9 @@
 package com.shopify.sample.util;
 
 import android.content.Context;
-import android.support.design.widget.CoordinatorLayout;
-import android.support.design.widget.FloatingActionButton;
-import android.support.v4.view.ViewCompat;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import androidx.core.view.ViewCompat;
 import android.util.AttributeSet;
 import android.view.View;
 

--- a/sample/src/main/java/com/shopify/sample/util/Util.java
+++ b/sample/src/main/java/com/shopify/sample/util/Util.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.util;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/sample/src/main/java/com/shopify/sample/util/WeakSingleObserver.java
+++ b/sample/src/main/java/com/shopify/sample/util/WeakSingleObserver.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.util;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import java.lang.ref.WeakReference;
 

--- a/sample/src/main/java/com/shopify/sample/view/BasePaginatedListViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/BasePaginatedListViewModel.java
@@ -1,8 +1,8 @@
 package com.shopify.sample.view;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.MutableLiveData;
-import android.support.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.util.WeakConsumer;
 import com.shopify.sample.util.WeakObserver;

--- a/sample/src/main/java/com/shopify/sample/view/BaseViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/BaseViewModel.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.view;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.shopify.sample.domain.model.UserMessageError;
 import com.shopify.sample.util.RequestRegister;
@@ -35,7 +35,7 @@ import io.reactivex.disposables.Disposable;
 import static com.shopify.sample.util.Util.checkNotNull;
 
 @SuppressWarnings("WeakerAccess")
-public abstract class BaseViewModel extends android.arch.lifecycle.ViewModel implements ViewModel {
+public abstract class BaseViewModel extends androidx.lifecycle.ViewModel implements ViewModel {
   private final ProgressLiveData progressLiveData = new ProgressLiveData();
   private final UserErrorCallback errorCallback = new UserErrorCallback();
   private final RequestRegister<Integer> requestRegister = new RequestRegister<>();

--- a/sample/src/main/java/com/shopify/sample/view/LifeCycleBoundCallback.java
+++ b/sample/src/main/java/com/shopify/sample/view/LifeCycleBoundCallback.java
@@ -24,20 +24,20 @@
 
 package com.shopify.sample.view;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleObserver;
-import android.arch.lifecycle.LifecycleOwner;
-import android.arch.lifecycle.LifecycleRegistry;
-import android.arch.lifecycle.Observer;
-import android.arch.lifecycle.OnLifecycleEvent;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.OnLifecycleEvent;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static android.arch.lifecycle.Lifecycle.State.DESTROYED;
-import static android.arch.lifecycle.Lifecycle.State.STARTED;
+import static androidx.lifecycle.Lifecycle.State.DESTROYED;
+import static androidx.lifecycle.Lifecycle.State.STARTED;
 
 public class LifeCycleBoundCallback<T> {
   private final List<LifecycleBoundObserver> observers = new LinkedList<>();

--- a/sample/src/main/java/com/shopify/sample/view/ProgressDialogHelper.java
+++ b/sample/src/main/java/com/shopify/sample/view/ProgressDialogHelper.java
@@ -26,8 +26,8 @@ package com.shopify.sample.view;
 
 import android.app.ProgressDialog;
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;

--- a/sample/src/main/java/com/shopify/sample/view/ProgressLiveData.java
+++ b/sample/src/main/java/com/shopify/sample/view/ProgressLiveData.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.view;
 
-import android.arch.lifecycle.LiveData;
+import androidx.lifecycle.LiveData;
 
 @SuppressWarnings("WeakerAccess")
 public final class ProgressLiveData extends LiveData<ProgressLiveData.Progress> {

--- a/sample/src/main/java/com/shopify/sample/view/ScreenActionEvent.java
+++ b/sample/src/main/java/com/shopify/sample/view/ScreenActionEvent.java
@@ -27,7 +27,7 @@ package com.shopify.sample.view;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.util.Util;
 

--- a/sample/src/main/java/com/shopify/sample/view/ScreenRouter.java
+++ b/sample/src/main/java/com/shopify/sample/view/ScreenRouter.java
@@ -26,7 +26,7 @@ package com.shopify.sample.view;
 
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.util.BiConsumer;
 import com.shopify.sample.view.cart.CartClickActionEvent;

--- a/sample/src/main/java/com/shopify/sample/view/UserErrorCallback.java
+++ b/sample/src/main/java/com/shopify/sample/view/UserErrorCallback.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.view;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public final class UserErrorCallback extends LifeCycleBoundCallback<UserErrorCallback.Error> {
 

--- a/sample/src/main/java/com/shopify/sample/view/ViewUtils.java
+++ b/sample/src/main/java/com/shopify/sample/view/ViewUtils.java
@@ -1,8 +1,8 @@
 package com.shopify.sample.view;
 
-import android.support.annotation.NonNull;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 public final class ViewUtils {
 

--- a/sample/src/main/java/com/shopify/sample/view/base/BasePaginatedListViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/base/BasePaginatedListViewModel.java
@@ -1,8 +1,8 @@
 package com.shopify.sample.view.base;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.MutableLiveData;
-import android.support.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.core.UseCase.Callback1;
 import com.shopify.sample.core.UseCase.Cancelable;

--- a/sample/src/main/java/com/shopify/sample/view/base/BaseViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/base/BaseViewModel.java
@@ -1,6 +1,6 @@
 package com.shopify.sample.view.base;
 
-import android.arch.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModel;
 
 import com.shopify.sample.BaseApplication;
 import com.shopify.sample.domain.usecases.UseCases;

--- a/sample/src/main/java/com/shopify/sample/view/base/LifecycleFrameLayout.java
+++ b/sample/src/main/java/com/shopify/sample/view/base/LifecycleFrameLayout.java
@@ -1,15 +1,15 @@
 package com.shopify.sample.view.base;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleOwner;
-import android.arch.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
 import android.content.Context;
 import android.os.Build;
-import android.support.annotation.AttrRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
-import android.support.annotation.StyleRes;
+import androidx.annotation.AttrRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.annotation.StyleRes;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
 

--- a/sample/src/main/java/com/shopify/sample/view/base/LifecycleSwipeRefreshLayout.java
+++ b/sample/src/main/java/com/shopify/sample/view/base/LifecycleSwipeRefreshLayout.java
@@ -1,10 +1,10 @@
 package com.shopify.sample.view.base;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleOwner;
-import android.arch.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
 import android.content.Context;
-import android.support.v4.widget.SwipeRefreshLayout;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import android.util.AttributeSet;
 
 public class LifecycleSwipeRefreshLayout extends SwipeRefreshLayout implements LifecycleOwner {

--- a/sample/src/main/java/com/shopify/sample/view/base/ListItemViewHolder.java
+++ b/sample/src/main/java/com/shopify/sample/view/base/ListItemViewHolder.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.view.base;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.view.View;
 
 import butterknife.ButterKnife;

--- a/sample/src/main/java/com/shopify/sample/view/base/ListItemViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/base/ListItemViewModel.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.view.base;
 
-import android.support.annotation.LayoutRes;
-import android.support.annotation.NonNull;
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
 
 public abstract class ListItemViewModel<T> {
   private final T payload;

--- a/sample/src/main/java/com/shopify/sample/view/base/RecyclerViewAdapter.java
+++ b/sample/src/main/java/com/shopify/sample/view/base/RecyclerViewAdapter.java
@@ -24,10 +24,10 @@
 
 package com.shopify.sample.view.base;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v7.util.DiffUtil;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.DiffUtil;
+import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/sample/src/main/java/com/shopify/sample/view/base/RecyclerViewItemHolder.java
+++ b/sample/src/main/java/com/shopify/sample/view/base/RecyclerViewItemHolder.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.view.base;
 
-import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 
 import static com.shopify.sample.util.Util.checkNotNull;

--- a/sample/src/main/java/com/shopify/sample/view/cart/AndroidPayConfirmationClickActionEvent.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/AndroidPayConfirmationClickActionEvent.java
@@ -26,7 +26,7 @@ package com.shopify.sample.view.cart;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import com.shopify.sample.domain.model.Cart;
 import com.shopify.sample.view.ScreenActionEvent;
 

--- a/sample/src/main/java/com/shopify/sample/view/cart/CartActivity.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/CartActivity.java
@@ -24,24 +24,26 @@
 
 package com.shopify.sample.view.cart;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleRegistry;
-import android.arch.lifecycle.LifecycleRegistryOwner;
-import android.arch.lifecycle.ViewModelProvider;
-import android.arch.lifecycle.ViewModelProviders;
-import android.arch.lifecycle.ViewModel;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.design.widget.Snackbar;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.View;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.LifecycleRegistryOwner;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
+
+import com.google.android.material.snackbar.Snackbar;
 import com.shopify.sample.BaseApplication;
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Checkout;
 import com.shopify.sample.domain.model.ShopSettings;
 import com.shopify.sample.view.ProgressDialogHelper;
@@ -52,10 +54,10 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public final class CartActivity extends AppCompatActivity implements LifecycleRegistryOwner {
-  @BindView(R.id.root) View rootView;
-  @BindView(R.id.cart_header) CartHeaderView cartHeaderView;
-  @BindView(R.id.cart_list) CartListView cartListView;
-  @BindView(R.id.toolbar) Toolbar toolbarView;
+  @BindView(R2.id.root) View rootView;
+  @BindView(R2.id.cart_header) CartHeaderView cartHeaderView;
+  @BindView(R2.id.cart_list) CartListView cartListView;
+  @BindView(R2.id.toolbar) Toolbar toolbarView;
 
   private final LifecycleRegistry lifecycleRegistry = new LifecycleRegistry(this);
   private CartDetailsViewModel cartDetailsViewModel;

--- a/sample/src/main/java/com/shopify/sample/view/cart/CartHeaderView.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/CartHeaderView.java
@@ -24,20 +24,22 @@
 
 package com.shopify.sample.view.cart;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleOwner;
-import android.arch.lifecycle.LifecycleRegistry;
-import android.arch.lifecycle.Transformations;
 import android.content.Context;
-import android.support.annotation.AttrRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import androidx.annotation.AttrRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.Transformations;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 
 import java.text.NumberFormat;
 
@@ -48,8 +50,8 @@ import butterknife.OnClick;
 public final class CartHeaderView extends FrameLayout implements LifecycleOwner {
   private static final NumberFormat CURRENCY_FORMAT = NumberFormat.getCurrencyInstance();
 
-  @BindView(R.id.android_pay_checkout) View androidPayCheckoutView;
-  @BindView(R.id.subtotal) TextView subtotalView;
+  @BindView(R2.id.android_pay_checkout) View androidPayCheckoutView;
+  @BindView(R2.id.subtotal) TextView subtotalView;
 
   private final LifecycleRegistry lifecycleRegistry = new LifecycleRegistry(this);
 

--- a/sample/src/main/java/com/shopify/sample/view/cart/CartHeaderViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/CartHeaderViewModel.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.view.cart;
 
-import android.arch.lifecycle.LiveData;
+import androidx.lifecycle.LiveData;
 
 import java.math.BigDecimal;
 

--- a/sample/src/main/java/com/shopify/sample/view/cart/CartListItemViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/CartListItemViewModel.java
@@ -24,11 +24,13 @@
 
 package com.shopify.sample.view.cart;
 
-import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.CartItem;
 import com.shopify.sample.view.base.ListItemViewHolder;
 import com.shopify.sample.view.base.ListItemViewModel;
@@ -73,12 +75,12 @@ final class CartListItemViewModel extends ListItemViewModel<CartItem> {
 
   static final class ItemViewHolder extends ListItemViewHolder<CartItem, ListItemViewModel<CartItem>> {
     static final NumberFormat CURRENCY_FORMAT = NumberFormat.getCurrencyInstance();
-    @BindView(R.id.image) ShopifyDraweeView imageView;
-    @BindView(R.id.title) TextView titleView;
-    @BindView(R.id.variant) TextView variantView;
-    @BindView(R.id.price) TextView priceView;
-    @BindView(R.id.quantity) TextView quantityView;
-    @BindView(R.id.divider) View dividerView;
+    @BindView(R2.id.image) ShopifyDraweeView imageView;
+    @BindView(R2.id.title) TextView titleView;
+    @BindView(R2.id.variant) TextView variantView;
+    @BindView(R2.id.price) TextView priceView;
+    @BindView(R2.id.quantity) TextView quantityView;
+    @BindView(R2.id.divider) View dividerView;
     final OnChangeQuantityClickListener onChangeQuantityClickListener;
 
     ItemViewHolder(@NonNull final OnChangeQuantityClickListener onChangeQuantityClickListener,

--- a/sample/src/main/java/com/shopify/sample/view/cart/CartListView.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/CartListView.java
@@ -24,18 +24,20 @@
 
 package com.shopify.sample.view.cart;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleOwner;
-import android.arch.lifecycle.LifecycleRegistry;
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.design.widget.Snackbar;
-import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.SimpleItemAnimator;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
 
+import androidx.annotation.NonNull;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.SimpleItemAnimator;
+
+import com.google.android.material.snackbar.Snackbar;
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.CartItem;
 import com.shopify.sample.view.BasePaginatedListViewModel;
 import com.shopify.sample.view.base.ListItemViewModel;
@@ -49,7 +51,7 @@ import butterknife.ButterKnife;
 import static com.shopify.sample.util.Util.checkNotNull;
 
 public final class CartListView extends FrameLayout implements LifecycleOwner {
-  @BindView(R.id.list) RecyclerView listView;
+  @BindView(R2.id.list) RecyclerView listView;
 
   private final LifecycleRegistry lifecycleRegistry = new LifecycleRegistry(this);
   private final RecyclerViewAdapter listViewAdapter = new RecyclerViewAdapter();

--- a/sample/src/main/java/com/shopify/sample/view/cart/CartListViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/CartListViewModel.java
@@ -1,6 +1,6 @@
 package com.shopify.sample.view.cart;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.interactor.CartAddItemInteractor;
 import com.shopify.sample.domain.interactor.CartFetchInteractor;

--- a/sample/src/main/java/com/shopify/sample/view/cart/CartSubtotalListItemViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/CartSubtotalListItemViewModel.java
@@ -25,14 +25,16 @@
 package com.shopify.sample.view.cart;
 
 import android.content.res.TypedArray;
-import android.support.annotation.NonNull;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Cart;
 import com.shopify.sample.view.base.ListItemViewHolder;
 import com.shopify.sample.view.base.ListItemViewModel;
@@ -62,7 +64,7 @@ final class CartSubtotalListItemViewModel extends ListItemViewModel<Cart> {
 
   static final class ItemViewHolder extends ListItemViewHolder<Cart, ListItemViewModel<Cart>> {
     static final NumberFormat CURRENCY_FORMAT = NumberFormat.getCurrencyInstance();
-    @BindView(R.id.subtotal) TextView subtotalView;
+    @BindView(R2.id.subtotal) TextView subtotalView;
     private int colorAccent;
 
     ItemViewHolder(@NonNull final OnClickListener onClickListener) {

--- a/sample/src/main/java/com/shopify/sample/view/cart/RealCartViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/cart/RealCartViewModel.java
@@ -24,11 +24,11 @@
 
 package com.shopify.sample.view.cart;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.MutableLiveData;
-import android.arch.lifecycle.Transformations;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Transformations;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import com.shopify.sample.domain.interactor.CartWatchInteractor;
 import com.shopify.sample.domain.interactor.CheckoutCreateInteractor;
 import com.shopify.sample.domain.interactor.RealCartWatchInteractor;

--- a/sample/src/main/java/com/shopify/sample/view/checkout/CheckoutActivity.java
+++ b/sample/src/main/java/com/shopify/sample/view/checkout/CheckoutActivity.java
@@ -24,25 +24,27 @@
 
 package com.shopify.sample.view.checkout;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleRegistry;
-import android.arch.lifecycle.LifecycleRegistryOwner;
-import android.arch.lifecycle.ViewModelProvider;
-import android.arch.lifecycle.ViewModelProviders;
-import android.arch.lifecycle.ViewModel;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.design.widget.Snackbar;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.LifecycleRegistryOwner;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
+
+import com.google.android.material.snackbar.Snackbar;
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.view.ProgressDialogHelper;
 
 import butterknife.BindView;
@@ -60,15 +62,15 @@ public final class CheckoutActivity extends AppCompatActivity implements Lifecyc
   public static final String EXTRAS_PAY_CART = "pay_cart";
   public static final String EXTRAS_MASKED_WALLET = "masked_wallet";
 
-  @BindView(R.id.root)
+  @BindView(R2.id.root)
   View rootView;
-  @BindView(R.id.toolbar)
+  @BindView(R2.id.toolbar)
   Toolbar toolbarView;
-  @BindView(R.id.total_summary)
+  @BindView(R2.id.total_summary)
   TotalSummaryView totalSummaryView;
-  @BindView(R.id.shipping_rates)
+  @BindView(R2.id.shipping_rates)
   ShippingRatesView shippingRatesView;
-  @BindView(R.id.confirm_layout)
+  @BindView(R2.id.confirm_layout)
   View confirmLayoutView;
 
   private String checkoutId;
@@ -237,7 +239,7 @@ public final class CheckoutActivity extends AppCompatActivity implements Lifecyc
     snackbar.getView().setBackgroundResource(R.color.snackbar_error_background);
     snackbar.getView().setMinimumHeight(confirmLayoutView.getHeight());
 
-    TextView textView = (TextView) snackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
+    TextView textView = snackbar.getView().findViewById(R.id.snackbar_text);
     ViewGroup.LayoutParams layoutParams = textView.getLayoutParams();
     layoutParams.height = confirmLayoutView.getHeight();
     textView.setLayoutParams(layoutParams);

--- a/sample/src/main/java/com/shopify/sample/view/checkout/CheckoutShippingRatesViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/checkout/CheckoutShippingRatesViewModel.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.view.checkout;
 
-import android.arch.lifecycle.LiveData;
-import android.support.annotation.Nullable;
+import androidx.lifecycle.LiveData;
+import androidx.annotation.Nullable;
 
 import com.shopify.sample.domain.model.Checkout;
 import com.shopify.sample.view.ViewModel;

--- a/sample/src/main/java/com/shopify/sample/view/checkout/RealCheckoutViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/checkout/RealCheckoutViewModel.java
@@ -24,9 +24,9 @@
 
 package com.shopify.sample.view.checkout;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.MutableLiveData;
-import android.support.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.interactor.CartClearInteractor;
 import com.shopify.sample.domain.interactor.CheckoutCompleteInteractor;

--- a/sample/src/main/java/com/shopify/sample/view/checkout/ShippingRateSelectDialog.java
+++ b/sample/src/main/java/com/shopify/sample/view/checkout/ShippingRateSelectDialog.java
@@ -25,17 +25,19 @@
 package com.shopify.sample.view.checkout;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.StyleRes;
-import android.support.design.widget.BottomSheetDialog;
-import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StyleRes;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Checkout.ShippingRate;
 import com.shopify.sample.domain.model.Checkout.ShippingRates;
 import com.shopify.sample.view.base.ListItemViewHolder;
@@ -53,8 +55,8 @@ import butterknife.OnClick;
 import static com.shopify.sample.util.Util.checkNotNull;
 
 public final class ShippingRateSelectDialog extends BottomSheetDialog implements RecyclerViewAdapter.OnItemClickListener {
-  @BindView(R.id.toolbar) Toolbar toolbarView;
-  @BindView(R.id.list) RecyclerView listView;
+  @BindView(R2.id.toolbar) Toolbar toolbarView;
+  @BindView(R2.id.list) RecyclerView listView;
 
   private final RecyclerViewAdapter listViewAdapter = new RecyclerViewAdapter(this);
   private OnShippingRateSelectListener onShippingRateSelectListener;
@@ -131,8 +133,8 @@ public final class ShippingRateSelectDialog extends BottomSheetDialog implements
   static final class ItemViewHolder extends ListItemViewHolder<ShippingRate, ListItemViewModel<ShippingRate>> {
     private static final NumberFormat CURRENCY_FORMAT = NumberFormat.getCurrencyInstance();
 
-    @BindView(R.id.title) TextView titleView;
-    @BindView(R.id.price) TextView priceView;
+    @BindView(R2.id.title) TextView titleView;
+    @BindView(R2.id.price) TextView priceView;
 
     ItemViewHolder(@NonNull final OnClickListener onClickListener) {
       super(onClickListener);

--- a/sample/src/main/java/com/shopify/sample/view/checkout/ShippingRatesView.java
+++ b/sample/src/main/java/com/shopify/sample/view/checkout/ShippingRatesView.java
@@ -24,17 +24,19 @@
 
 package com.shopify.sample.view.checkout;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleOwner;
-import android.arch.lifecycle.LifecycleRegistry;
-import android.arch.lifecycle.Transformations;
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.constraint.ConstraintLayout;
 import android.util.AttributeSet;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.Transformations;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Checkout;
 
 import java.text.NumberFormat;
@@ -46,8 +48,8 @@ import butterknife.OnClick;
 public final class ShippingRatesView extends ConstraintLayout implements LifecycleOwner {
   private static final NumberFormat CURRENCY_FORMAT = NumberFormat.getCurrencyInstance();
 
-  @BindView(R.id.shipping_line) TextView shippingLineView;
-  @BindView(R.id.price) TextView priceView;
+  @BindView(R2.id.shipping_line) TextView shippingLineView;
+  @BindView(R2.id.price) TextView priceView;
 
   private final LifecycleRegistry lifecycleRegistry = new LifecycleRegistry(this);
   private CheckoutShippingRatesViewModel viewModel;

--- a/sample/src/main/java/com/shopify/sample/view/checkout/TotalSummaryView.java
+++ b/sample/src/main/java/com/shopify/sample/view/checkout/TotalSummaryView.java
@@ -25,12 +25,14 @@
 package com.shopify.sample.view.checkout;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.constraint.ConstraintLayout;
 import android.util.AttributeSet;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.constraintlayout.widget.ConstraintLayout;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 
 import java.math.BigDecimal;
 import java.text.NumberFormat;
@@ -43,10 +45,10 @@ import static com.shopify.sample.util.Util.checkNotNull;
 public final class TotalSummaryView extends ConstraintLayout {
   private static final NumberFormat CURRENCY_FORMAT = NumberFormat.getCurrencyInstance();
 
-  @BindView(R.id.subtotal) TextView subtotalView;
-  @BindView(R.id.shipping) TextView shippingView;
-  @BindView(R.id.tax) TextView taxView;
-  @BindView(R.id.total) TextView totalView;
+  @BindView(R2.id.subtotal) TextView subtotalView;
+  @BindView(R2.id.shipping) TextView shippingView;
+  @BindView(R2.id.tax) TextView taxView;
+  @BindView(R2.id.total) TextView totalView;
 
   public TotalSummaryView(final Context context) {
     super(context);

--- a/sample/src/main/java/com/shopify/sample/view/collections/CollectionClickActionEvent.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/CollectionClickActionEvent.java
@@ -26,7 +26,7 @@ package com.shopify.sample.view.collections;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.Collection;
 import com.shopify.sample.view.ScreenActionEvent;

--- a/sample/src/main/java/com/shopify/sample/view/collections/CollectionDescriptionSummaryListItemViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/CollectionDescriptionSummaryListItemViewModel.java
@@ -24,12 +24,14 @@
 
 package com.shopify.sample.view.collections;
 
-import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Collection;
 import com.shopify.sample.view.base.ListItemViewHolder;
 import com.shopify.sample.view.base.ListItemViewModel;
@@ -64,7 +66,7 @@ final class CollectionDescriptionSummaryListItemViewModel extends ListItemViewMo
   }
 
   static final class ItemViewHolder extends ListItemViewHolder<Collection, ListItemViewModel<Collection>> {
-    @BindView(R.id.description) TextView descriptionView;
+    @BindView(R2.id.description) TextView descriptionView;
 
     ItemViewHolder(@NonNull final OnClickListener onClickListener) {
       super(onClickListener);

--- a/sample/src/main/java/com/shopify/sample/view/collections/CollectionDividerListItemViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/CollectionDividerListItemViewModel.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.view.collections;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.R;
 import com.shopify.sample.domain.model.Collection;

--- a/sample/src/main/java/com/shopify/sample/view/collections/CollectionImageListItemViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/CollectionImageListItemViewModel.java
@@ -24,9 +24,10 @@
 
 package com.shopify.sample.view.collections;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Collection;
 import com.shopify.sample.view.base.ListItemViewHolder;
 import com.shopify.sample.view.base.ListItemViewModel;
@@ -63,7 +64,7 @@ final class CollectionImageListItemViewModel extends ListItemViewModel<Collectio
   }
 
   static final class ItemViewHolder extends ListItemViewHolder<Collection, ListItemViewModel<Collection>> {
-    @BindView(R.id.image) ShopifyDraweeView imageView;
+    @BindView(R2.id.image) ShopifyDraweeView imageView;
 
     ItemViewHolder(@NonNull final ListItemViewHolder.OnClickListener onClickListener) {
       super(onClickListener);

--- a/sample/src/main/java/com/shopify/sample/view/collections/CollectionListActivity.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/CollectionListActivity.java
@@ -24,15 +24,17 @@
 
 package com.shopify.sample.view.collections;
 
-import android.arch.lifecycle.ViewModelProviders;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuInflater;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.ViewModelProviders;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.view.ScreenRouter;
 import com.shopify.sample.view.cart.CartClickActionEvent;
 
@@ -41,8 +43,8 @@ import butterknife.ButterKnife;
 
 public final class CollectionListActivity extends AppCompatActivity {
 
-  @BindView(R.id.collection_list) CollectionListView collectionListView;
-  @BindView(R.id.toolbar) Toolbar toolbarView;
+  @BindView(R2.id.collection_list) CollectionListView collectionListView;
+  @BindView(R2.id.toolbar) Toolbar toolbarView;
 
   @SuppressWarnings("ConstantConditions")
   @Override

--- a/sample/src/main/java/com/shopify/sample/view/collections/CollectionListView.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/CollectionListView.java
@@ -25,16 +25,18 @@
 package com.shopify.sample.view.collections;
 
 import android.content.Context;
-import android.support.annotation.AttrRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.design.widget.Snackbar;
-import android.support.v4.widget.SwipeRefreshLayout;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 
+import androidx.annotation.AttrRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
+import com.google.android.material.snackbar.Snackbar;
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Collection;
 import com.shopify.sample.view.Constant;
 import com.shopify.sample.view.ScreenRouter;
@@ -50,8 +52,8 @@ import butterknife.ButterKnife;
 public final class CollectionListView extends LifecycleFrameLayout implements OnNextPageListener,
         SwipeRefreshLayout.OnRefreshListener, RecyclerViewAdapter.OnItemClickListener {
 
-  @BindView(R.id.list) RecyclerView listView;
-  @BindView(R.id.swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayoutView;
+  @BindView(R2.id.list) RecyclerView listView;
+  @BindView(R2.id.swipe_refresh_layout) SwipeRefreshLayout swipeRefreshLayoutView;
 
   private RecyclerViewAdapter adapter;
   private CollectionListViewModel viewModel;

--- a/sample/src/main/java/com/shopify/sample/view/collections/CollectionListViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/CollectionListViewModel.java
@@ -1,8 +1,8 @@
 package com.shopify.sample.view.collections;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.Transformations;
-import android.support.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.Transformations;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.core.UseCase.Cancelable;
 import com.shopify.sample.domain.model.Collection;

--- a/sample/src/main/java/com/shopify/sample/view/collections/CollectionProductClickActionEvent.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/CollectionProductClickActionEvent.java
@@ -26,7 +26,7 @@ package com.shopify.sample.view.collections;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.Product;
 import com.shopify.sample.view.ScreenActionEvent;

--- a/sample/src/main/java/com/shopify/sample/view/collections/CollectionTitleListItemViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/CollectionTitleListItemViewModel.java
@@ -24,10 +24,12 @@
 
 package com.shopify.sample.view.collections;
 
-import android.support.annotation.NonNull;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Collection;
 import com.shopify.sample.view.base.ListItemViewHolder;
 import com.shopify.sample.view.base.ListItemViewModel;
@@ -62,7 +64,7 @@ final class CollectionTitleListItemViewModel extends ListItemViewModel<Collectio
   }
 
   static final class ItemViewHolder extends ListItemViewHolder<Collection, ListItemViewModel<Collection>> {
-    @BindView(R.id.title) TextView titleView;
+    @BindView(R2.id.title) TextView titleView;
 
     ItemViewHolder(@NonNull final OnClickListener onClickListener) {
       super(onClickListener);

--- a/sample/src/main/java/com/shopify/sample/view/collections/ProductListItemViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/ProductListItemViewModel.java
@@ -24,10 +24,12 @@
 
 package com.shopify.sample.view.collections;
 
-import android.support.annotation.NonNull;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Product;
 import com.shopify.sample.view.base.ListItemViewHolder;
 import com.shopify.sample.view.base.ListItemViewModel;
@@ -48,7 +50,7 @@ final class ProductListItemViewModel extends ListItemViewModel<Product> {
   }
 
   static final class ItemViewHolder extends ListItemViewHolder<Product, ListItemViewModel<Product>> {
-    @BindView(R.id.image) ShopifyDraweeView imageView;
+    @BindView(R2.id.image) ShopifyDraweeView imageView;
 
     ItemViewHolder(@NonNull final OnClickListener onClickListener) {
       super(onClickListener);

--- a/sample/src/main/java/com/shopify/sample/view/collections/ProductListView.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/ProductListView.java
@@ -26,16 +26,18 @@ package com.shopify.sample.view.collections;
 
 import android.content.Context;
 import android.graphics.Rect;
-import android.support.annotation.AttrRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.FrameLayout;
 
+import androidx.annotation.AttrRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Product;
 import com.shopify.sample.view.ScreenRouter;
 import com.shopify.sample.view.base.ListItemViewModel;
@@ -48,7 +50,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 
 public final class ProductListView extends FrameLayout implements RecyclerViewAdapter.OnItemClickListener {
-  @BindView(R.id.list) RecyclerView listView;
+  @BindView(R2.id.list) RecyclerView listView;
   private final RecyclerViewAdapter listViewAdapter = new RecyclerViewAdapter(this);
 
   public ProductListView(@NonNull final Context context) {

--- a/sample/src/main/java/com/shopify/sample/view/collections/ProductsListItemViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/collections/ProductsListItemViewModel.java
@@ -24,9 +24,10 @@
 
 package com.shopify.sample.view.collections;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Product;
 import com.shopify.sample.view.base.ListItemViewHolder;
 import com.shopify.sample.view.base.ListItemViewModel;
@@ -78,7 +79,7 @@ final class ProductsListItemViewModel extends ListItemViewModel<List<Product>> {
   }
 
   static final class ItemViewHolder extends ListItemViewHolder<List<Product>, ListItemViewModel<List<Product>>> {
-    @BindView(R.id.product_list) ProductListView productListView;
+    @BindView(R2.id.product_list) ProductListView productListView;
 
     ItemViewHolder(@NonNull final OnClickListener onClickListener) {
       super(onClickListener);

--- a/sample/src/main/java/com/shopify/sample/view/product/ProductDescriptionView.java
+++ b/sample/src/main/java/com/shopify/sample/view/product/ProductDescriptionView.java
@@ -25,12 +25,14 @@
 package com.shopify.sample.view.product;
 
 import android.content.Context;
-import android.support.v4.widget.NestedScrollView;
 import android.text.Html;
 import android.util.AttributeSet;
 import android.widget.TextView;
 
+import androidx.core.widget.NestedScrollView;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.ProductDetails;
 
 import java.math.BigDecimal;
@@ -47,9 +49,9 @@ import static com.shopify.sample.util.Util.minItem;
 public final class ProductDescriptionView extends NestedScrollView {
   static final NumberFormat CURRENCY_FORMAT = NumberFormat.getCurrencyInstance();
 
-  @BindView(R.id.title) TextView titleView;
-  @BindView(R.id.price) TextView priceView;
-  @BindView(R.id.description) TextView descriptionView;
+  @BindView(R2.id.title) TextView titleView;
+  @BindView(R2.id.price) TextView priceView;
+  @BindView(R2.id.description) TextView descriptionView;
   private OnAddToCartClickListener onAddToCartClickListener;
 
   public ProductDescriptionView(final Context context) {

--- a/sample/src/main/java/com/shopify/sample/view/product/ProductDetailsActivity.java
+++ b/sample/src/main/java/com/shopify/sample/view/product/ProductDetailsActivity.java
@@ -24,24 +24,26 @@
 
 package com.shopify.sample.view.product;
 
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleRegistry;
-import android.arch.lifecycle.LifecycleRegistryOwner;
-import android.arch.lifecycle.ViewModel;
-import android.arch.lifecycle.ViewModelProvider;
-import android.arch.lifecycle.ViewModelProviders;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.design.widget.Snackbar;
-import android.support.v4.widget.SwipeRefreshLayout;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.LifecycleRegistryOwner;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
+import com.google.android.material.snackbar.Snackbar;
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.ProductDetails;
 import com.shopify.sample.view.ScreenRouter;
 import com.shopify.sample.view.cart.CartClickActionEvent;
@@ -60,11 +62,11 @@ public final class ProductDetailsActivity extends AppCompatActivity implements L
   public static final String EXTRAS_PRODUCT_TITLE = "product_title";
   public static final String EXTRAS_PRODUCT_PRICE = "product_price";
 
-  @BindView(R.id.root) View rootView;
-  @BindView(R.id.swipe_refresh) SwipeRefreshLayout swipeRefreshLayoutView;
-  @BindView(R.id.toolbar) Toolbar toolbarView;
-  @BindView(R.id.image_gallery) ImageGalleryView imageGalleryView;
-  @BindView(R.id.product_description) ProductDescriptionView productDescriptionView;
+  @BindView(R2.id.root) View rootView;
+  @BindView(R2.id.swipe_refresh) SwipeRefreshLayout swipeRefreshLayoutView;
+  @BindView(R2.id.toolbar) Toolbar toolbarView;
+  @BindView(R2.id.image_gallery) ImageGalleryView imageGalleryView;
+  @BindView(R2.id.product_description) ProductDescriptionView productDescriptionView;
 
   private final LifecycleRegistry lifecycleRegistry = new LifecycleRegistry(this);
   private ProductViewModel productViewModel;

--- a/sample/src/main/java/com/shopify/sample/view/product/ProductViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/product/ProductViewModel.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.view.product;
 
-import android.arch.lifecycle.LiveData;
+import androidx.lifecycle.LiveData;
 
 import com.shopify.sample.domain.model.ProductDetails;
 import com.shopify.sample.view.ViewModel;

--- a/sample/src/main/java/com/shopify/sample/view/product/RealProductViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/product/RealProductViewModel.java
@@ -24,9 +24,9 @@
 
 package com.shopify.sample.view.product;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.MutableLiveData;
-import android.support.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.interactor.CartAddItemInteractor;
 import com.shopify.sample.domain.interactor.ProductByIdInteractor;

--- a/sample/src/main/java/com/shopify/sample/view/products/ProductClickActionEvent.java
+++ b/sample/src/main/java/com/shopify/sample/view/products/ProductClickActionEvent.java
@@ -26,7 +26,7 @@ package com.shopify.sample.view.products;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.domain.model.Product;
 import com.shopify.sample.view.ScreenActionEvent;

--- a/sample/src/main/java/com/shopify/sample/view/products/ProductListActivity.java
+++ b/sample/src/main/java/com/shopify/sample/view/products/ProductListActivity.java
@@ -24,17 +24,19 @@
 
 package com.shopify.sample.view.products;
 
-import android.arch.lifecycle.ViewModel;
-import android.arch.lifecycle.ViewModelProvider;
-import android.arch.lifecycle.ViewModelProviders;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuInflater;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.view.ScreenRouter;
 import com.shopify.sample.view.cart.CartClickActionEvent;
 import com.shopify.sample.view.widget.image.ShopifyDraweeView;
@@ -50,9 +52,9 @@ public final class ProductListActivity extends AppCompatActivity {
   public static final String EXTRAS_COLLECTION_IMAGE_URL = "collection_image_url";
   public static final String EXTRAS_COLLECTION_TITLE = "collection_title";
 
-  @BindView(R.id.toolbar) Toolbar toolbarView;
-  @BindView(R.id.collection_image) ShopifyDraweeView collectionImageView;
-  @BindView(R.id.product_list) ProductListView productListView;
+  @BindView(R2.id.toolbar) Toolbar toolbarView;
+  @BindView(R2.id.collection_image) ShopifyDraweeView collectionImageView;
+  @BindView(R2.id.product_list) ProductListView productListView;
 
   @Override
   protected void onCreate(@Nullable final Bundle savedInstanceState) {

--- a/sample/src/main/java/com/shopify/sample/view/products/ProductListItemViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/products/ProductListItemViewModel.java
@@ -24,10 +24,12 @@
 
 package com.shopify.sample.view.products;
 
-import android.support.annotation.NonNull;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Product;
 import com.shopify.sample.view.base.ListItemViewHolder;
 import com.shopify.sample.view.base.ListItemViewModel;
@@ -71,9 +73,9 @@ final class ProductListItemViewModel extends ListItemViewModel<Product> {
   static final class ItemViewHolder extends ListItemViewHolder<Product, ListItemViewModel<Product>> {
 
     static final NumberFormat CURRENCY_FORMAT = NumberFormat.getCurrencyInstance();
-    @BindView(R.id.image) ShopifyDraweeView imageView;
-    @BindView(R.id.title) TextView titleView;
-    @BindView(R.id.price) TextView priceView;
+    @BindView(R2.id.image) ShopifyDraweeView imageView;
+    @BindView(R2.id.title) TextView titleView;
+    @BindView(R2.id.price) TextView priceView;
 
     ItemViewHolder(@NonNull final OnClickListener onClickListener) {
       super(onClickListener);

--- a/sample/src/main/java/com/shopify/sample/view/products/ProductListView.java
+++ b/sample/src/main/java/com/shopify/sample/view/products/ProductListView.java
@@ -26,14 +26,16 @@ package com.shopify.sample.view.products;
 
 import android.content.Context;
 import android.graphics.Rect;
-import android.support.annotation.NonNull;
-import android.support.design.widget.Snackbar;
-import android.support.v7.widget.GridLayoutManager;
-import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.snackbar.Snackbar;
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Product;
 import com.shopify.sample.view.Constant;
 import com.shopify.sample.view.ScreenRouter;
@@ -45,7 +47,7 @@ import com.shopify.sample.view.collections.CollectionListViewModel;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
-import static android.support.v4.widget.SwipeRefreshLayout.OnRefreshListener;
+import static androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener;
 import static com.shopify.sample.view.ViewUtils.OnNextPageListener;
 import static com.shopify.sample.view.ViewUtils.setOnNextPageListener;
 import static com.shopify.sample.view.base.RecyclerViewAdapter.OnItemClickListener;
@@ -53,7 +55,7 @@ import static com.shopify.sample.view.base.RecyclerViewAdapter.OnItemClickListen
 public final class ProductListView extends LifecycleSwipeRefreshLayout implements
         OnItemClickListener, OnNextPageListener, OnRefreshListener {
 
-  @BindView(R.id.list) RecyclerView listView;
+  @BindView(R2.id.list) RecyclerView listView;
 
   private RecyclerViewAdapter adapter;
   private ProductListViewModel viewModel;

--- a/sample/src/main/java/com/shopify/sample/view/products/ProductListViewModel.java
+++ b/sample/src/main/java/com/shopify/sample/view/products/ProductListViewModel.java
@@ -1,8 +1,8 @@
 package com.shopify.sample.view.products;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.Transformations;
-import android.support.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.Transformations;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.core.UseCase;
 import com.shopify.sample.domain.model.Product;

--- a/sample/src/main/java/com/shopify/sample/view/widget/CartBadgeView.java
+++ b/sample/src/main/java/com/shopify/sample/view/widget/CartBadgeView.java
@@ -25,15 +25,16 @@
 package com.shopify.sample.view.widget;
 
 import android.content.Context;
-import android.support.annotation.AttrRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
-import com.shopify.sample.R;
+import androidx.annotation.AttrRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.shopify.sample.R2;
 import com.shopify.sample.domain.model.Cart;
 import com.shopify.sample.domain.repository.CartRepository;
 import com.shopify.sample.domain.repository.RealCartRepository;
@@ -45,7 +46,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 
 public final class CartBadgeView extends FrameLayout {
-  @BindView(R.id.count) TextView countView;
+  @BindView(R2.id.count) TextView countView;
 
   private CartRepository cartRepository = new RealCartRepository();
   private Disposable cartSubscription;

--- a/sample/src/main/java/com/shopify/sample/view/widget/image/ImageGalleryView.java
+++ b/sample/src/main/java/com/shopify/sample/view/widget/image/ImageGalleryView.java
@@ -26,15 +26,17 @@ package com.shopify.sample.view.widget.image;
 
 import android.content.Context;
 import android.graphics.Rect;
-import android.support.annotation.NonNull;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.PagerSnapHelper;
-import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.FrameLayout;
 
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.PagerSnapHelper;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.shopify.sample.R;
+import com.shopify.sample.R2;
 import com.shopify.sample.util.Util;
 import com.shopify.sample.view.base.ListItemViewHolder;
 import com.shopify.sample.view.base.ListItemViewModel;
@@ -50,9 +52,9 @@ import butterknife.OnClick;
 import static com.shopify.sample.util.Util.checkNotNull;
 
 public final class ImageGalleryView extends FrameLayout implements RecyclerViewAdapter.OnItemClickListener {
-  @BindView(R.id.pager) RecyclerView pagerView;
-  @BindView(R.id.pager_indicator) RecyclerView pagerIndicatorView;
-  @BindView(R.id.pager_indicator_frame) View pagerIndicatorFrameView;
+  @BindView(R2.id.pager) RecyclerView pagerView;
+  @BindView(R2.id.pager_indicator) RecyclerView pagerIndicatorView;
+  @BindView(R2.id.pager_indicator_frame) View pagerIndicatorFrameView;
 
   private final RecyclerViewAdapter pagerAdapter = new RecyclerViewAdapter();
   private final RecyclerViewAdapter pagerIndicatorAdapter = new RecyclerViewAdapter(this);
@@ -167,7 +169,7 @@ public final class ImageGalleryView extends FrameLayout implements RecyclerViewA
     }
 
     static final class ItemViewHolder extends ListItemViewHolder<String, ListItemViewModel<String>> {
-      @BindView(R.id.image) ShopifyDraweeView imageView;
+      @BindView(R2.id.image) ShopifyDraweeView imageView;
 
       ItemViewHolder(@NonNull final OnClickListener onClickListener) {
         super(onClickListener);
@@ -199,7 +201,7 @@ public final class ImageGalleryView extends FrameLayout implements RecyclerViewA
     }
 
     static final class ItemViewHolder extends ListItemViewHolder<String, ListItemViewModel<String>> {
-      @BindView(R.id.image) ShopifyDraweeView imageView;
+      @BindView(R2.id.image) ShopifyDraweeView imageView;
 
       ItemViewHolder(@NonNull final OnClickListener onClickListener) {
         super(onClickListener);

--- a/sample/src/main/java/com/shopify/sample/view/widget/image/ShopifyDraweeView.java
+++ b/sample/src/main/java/com/shopify/sample/view/widget/image/ShopifyDraweeView.java
@@ -26,7 +26,7 @@ package com.shopify.sample.view.widget.image;
 
 import android.content.Context;
 import android.net.Uri;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 

--- a/sample/src/main/res/layout/activity_cart.xml
+++ b/sample/src/main/res/layout/activity_cart.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?android:attr/actionBarSize"
@@ -33,14 +33,14 @@
         android:layout_weight="1"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <android.support.v7.widget.RecyclerView
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="@android:color/transparent"
             android:clipToPadding="false"
             android:orientation="vertical"
-            app:layoutManager="android.support.v7.widget.LinearLayoutManager" />
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
     </com.shopify.sample.view.cart.CartListView>
 
 </LinearLayout>

--- a/sample/src/main/res/layout/activity_checkout.xml
+++ b/sample/src/main/res/layout/activity_checkout.xml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?android:attr/actionBarSize"

--- a/sample/src/main/res/layout/activity_collection_list.xml
+++ b/sample/src/main/res/layout/activity_collection_list.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -7,17 +7,17 @@
     android:fitsSystemWindows="true"
     tools:context=".view.collections.CollectionListActivity">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?android:attr/actionBarSize"
             android:background="?android:attr/colorPrimary" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <com.shopify.sample.view.collections.CollectionListView
         android:id="@+id/collection_list"
@@ -25,18 +25,18 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <android.support.v4.widget.SwipeRefreshLayout
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/swipe_refresh_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <android.support.v7.widget.RecyclerView
+            <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/list"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@android:color/transparent"
                 android:clipToPadding="false"
                 android:listDivider="@android:color/holo_green_dark" />
-        </android.support.v4.widget.SwipeRefreshLayout>
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
     </com.shopify.sample.view.collections.CollectionListView>
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/sample/src/main/res/layout/activity_product_details.xml
+++ b/sample/src/main/res/layout/activity_product_details.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout android:id="@+id/root"
+<androidx.coordinatorlayout.widget.CoordinatorLayout android:id="@+id/root"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@android:color/transparent">
 
-        <android.support.design.widget.CollapsingToolbarLayout
+        <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsing_toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -31,7 +31,7 @@
                     android:layout_height="wrap_content" />
             </com.shopify.sample.view.widget.image.ImageGalleryView>
 
-            <android.support.v7.widget.Toolbar
+            <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?android:attr/actionBarSize"
@@ -39,10 +39,10 @@
                 app:contentInsetStartWithNavigation="0dp"
                 app:layout_collapseMode="pin" />
 
-        </android.support.design.widget.CollapsingToolbarLayout>
-    </android.support.design.widget.AppBarLayout>
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
-    <android.support.v4.widget.SwipeRefreshLayout
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_refresh"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -59,6 +59,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
         </com.shopify.sample.view.product.ProductDescriptionView>
-    </android.support.v4.widget.SwipeRefreshLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/sample/src/main/res/layout/activity_product_list.xml
+++ b/sample/src/main/res/layout/activity_product_list.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fitsSystemWindows="true"
         app:layout_behavior="com.shopify.sample.util.FlingBehavior">
 
-        <android.support.design.widget.CollapsingToolbarLayout
+        <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsing_toolbar"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -34,15 +34,15 @@
                 app:overlayImage="@drawable/collection_image_overlay_scrim"
                 app:viewAspectRatio="1.77" />
 
-            <android.support.v7.widget.Toolbar
+            <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?android:attr/actionBarSize"
                 app:contentInsetStartWithNavigation="0dp"
                 app:layout_collapseMode="pin" />
-        </android.support.design.widget.CollapsingToolbarLayout>
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <com.shopify.sample.view.products.ProductListView
         android:id="@+id/product_list"
@@ -50,7 +50,7 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <android.support.v7.widget.RecyclerView
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -61,4 +61,4 @@
 
     </com.shopify.sample.view.products.ProductListView>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/sample/src/main/res/layout/cart_header.xml
+++ b/sample/src/main/res/layout/cart_header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -70,4 +70,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/title2" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/cart_list_item.xml
+++ b/sample/src/main/res/layout/cart_list_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -21,7 +21,7 @@
         app:layout_constraintRight_toLeftOf="@+id/guideline"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <android.support.constraint.Guideline
+    <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -148,4 +148,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/collection_products_list_item.xml
+++ b/sample/src/main/res/layout/collection_products_list_item.xml
@@ -6,7 +6,7 @@
     android:paddingBottom="@dimen/default_padding_half"
     android:paddingTop="@dimen/default_padding_half">
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/sample/src/main/res/layout/image_gallery.xml
+++ b/sample/src/main/res/layout/image_gallery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -7,7 +7,7 @@
     android:orientation="vertical"
     android:paddingBottom="@dimen/default_padding_half">
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/pager"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -20,7 +20,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.0" />
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/pager_indicator"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -28,7 +28,7 @@
         android:orientation="horizontal"
         android:paddingBottom="@dimen/default_padding_half"
         android:paddingTop="@dimen/default_padding_half"
-        app:layoutManager="android.support.v7.widget.LinearLayoutManager"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
@@ -48,4 +48,4 @@
         app:layout_constraintLeft_toLeftOf="@+id/pager_indicator"
         app:layout_constraintTop_toTopOf="@+id/pager_indicator" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/product_description.xml
+++ b/sample/src/main/res/layout/product_description.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -54,4 +54,4 @@
         It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.
         It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
         publishing software like Aldus PageMaker including versions of Lorem Ipsum." />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/shipping_rate_list.xml
+++ b/sample/src/main/res/layout/shipping_rate_list.xml
@@ -27,7 +27,7 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
@@ -35,7 +35,7 @@
         app:contentInsetStartWithNavigation="0dp"
         app:titleTextAppearance="@style/Shopify.TitleText" />
 
-    <android.support.v7.widget.RecyclerView android:id="@+id/list"
+    <androidx.recyclerview.widget.RecyclerView android:id="@+id/list"
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
@@ -45,5 +45,5 @@
         android:orientation="vertical"
         android:paddingBottom="@dimen/default_padding_half"
         android:paddingTop="@dimen/default_padding_half"
-        app:layoutManager="android.support.v7.widget.LinearLayoutManager" />
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 </LinearLayout>

--- a/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCheckoutCompleteInteractor.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCheckoutCompleteInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.buy3.GraphError;
 import com.shopify.buy3.Storefront;

--- a/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCheckoutCreateInteractor.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCheckoutCreateInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.buy3.Storefront;
 import com.shopify.graphql.support.ID;

--- a/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCheckoutShippingAddressUpdateInteractor.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCheckoutShippingAddressUpdateInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.buy3.Storefront;
 import com.shopify.sample.SampleApplication;

--- a/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCheckoutShippingLineUpdateInteractor.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCheckoutShippingLineUpdateInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.SampleApplication;
 import com.shopify.sample.domain.model.Checkout;

--- a/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCheckoutShippingRatesInteractor.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCheckoutShippingRatesInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.buy3.GraphError;
 import com.shopify.sample.SampleApplication;

--- a/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCollectionNextPageInteractor.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCollectionNextPageInteractor.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.shopify.buy3.Storefront;
 import com.shopify.sample.SampleApplication;

--- a/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCollectionProductNextPageInteractor.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealCollectionProductNextPageInteractor.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.shopify.buy3.Storefront;
 import com.shopify.sample.SampleApplication;

--- a/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealProductByIdInteractor.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealProductByIdInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.buy3.Storefront;
 import com.shopify.sample.SampleApplication;

--- a/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealShopSettingInteractor.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/interactor/RealShopSettingInteractor.java
@@ -1,6 +1,6 @@
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.buy3.Storefront;
 import com.shopify.sample.SampleApplication;

--- a/sample/src/shopify/java/com/shopify/sample/domain/repository/CheckoutRepository.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/repository/CheckoutRepository.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.repository;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.buy3.GraphCall;
 import com.shopify.buy3.GraphClient;

--- a/sample/src/shopify/java/com/shopify/sample/domain/repository/CollectionRepository.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/repository/CollectionRepository.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.repository;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.shopify.buy3.GraphCall;

--- a/sample/src/shopify/java/com/shopify/sample/domain/repository/ProductRepository.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/repository/ProductRepository.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.repository;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.shopify.buy3.GraphCall;

--- a/sample/src/shopify/java/com/shopify/sample/domain/repository/ShopRepository.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/repository/ShopRepository.java
@@ -1,6 +1,6 @@
 package com.shopify.sample.domain.repository;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.buy3.GraphCall;
 import com.shopify.buy3.GraphClient;
@@ -10,7 +10,6 @@ import com.shopify.sample.RxUtil;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
 
-import static com.shopify.sample.RxUtil.rxGraphQueryCall;
 import static com.shopify.sample.util.Util.checkNotNull;
 
 public final class ShopRepository {

--- a/sample/src/shopify/java/com/shopify/sample/domain/usecases/FetchCollectionsUseCaseImpl.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/usecases/FetchCollectionsUseCaseImpl.java
@@ -1,7 +1,7 @@
 package com.shopify.sample.domain.usecases;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.shopify.buy3.GraphCallResult;
 import com.shopify.buy3.GraphClient;
 import com.shopify.buy3.QueryGraphCall;

--- a/sample/src/shopify/java/com/shopify/sample/domain/usecases/FetchProductsUseCaseImpl.java
+++ b/sample/src/shopify/java/com/shopify/sample/domain/usecases/FetchProductsUseCaseImpl.java
@@ -1,7 +1,7 @@
 package com.shopify.sample.domain.usecases;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.shopify.buy3.GraphCallResult;
 import com.shopify.buy3.GraphClient;
 import com.shopify.buy3.QueryGraphCall;
@@ -15,7 +15,6 @@ import com.shopify.sample.domain.model.Product;
 import com.shopify.sample.util.CallbackExecutors;
 import com.shopify.sample.view.Constant;
 import kotlin.Unit;
-import kotlin.jvm.functions.Function1;
 
 import java.util.List;
 

--- a/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealCheckoutCompleteInteractor.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealCheckoutCompleteInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import com.apollographql.apollo.exception.ApolloHttpException;
 import com.apollographql.apollo.exception.ApolloNetworkException;
 import com.shopify.sample.SampleApplication;

--- a/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealCheckoutCreateInteractor.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealCheckoutCreateInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.SampleApplication;
 import com.shopify.sample.domain.CheckoutCreateQuery;

--- a/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealCheckoutShippingAddressUpdateInteractor.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealCheckoutShippingAddressUpdateInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.SampleApplication;
 import com.shopify.sample.domain.CheckoutShippingAddressUpdateQuery;

--- a/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealCheckoutShippingLineUpdateInteractor.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealCheckoutShippingLineUpdateInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.SampleApplication;
 import com.shopify.sample.domain.CheckoutShippingLineUpdateQuery;

--- a/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealCheckoutShippingRatesInteractor.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealCheckoutShippingRatesInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.apollographql.apollo.exception.ApolloHttpException;
 import com.apollographql.apollo.exception.ApolloNetworkException;

--- a/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealProductByIdInteractor.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/interactor/RealProductByIdInteractor.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.interactor;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.shopify.sample.SampleApplication;
 import com.shopify.sample.domain.ProductByIdQuery;

--- a/sample/src/xApollo/java/com/shopify/sample/domain/repository/CheckoutRepository.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/repository/CheckoutRepository.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.repository;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.apollographql.apollo.ApolloClient;
 import com.apollographql.apollo.ApolloQueryCall;

--- a/sample/src/xApollo/java/com/shopify/sample/domain/repository/CollectionRepository.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/repository/CollectionRepository.java
@@ -24,8 +24,8 @@
 
 package com.shopify.sample.domain.repository;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.apollographql.apollo.ApolloClient;
 import com.apollographql.apollo.api.internal.Optional;

--- a/sample/src/xApollo/java/com/shopify/sample/domain/repository/ProductRepository.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/repository/ProductRepository.java
@@ -24,7 +24,7 @@
 
 package com.shopify.sample.domain.repository;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.apollographql.apollo.ApolloClient;
 import com.apollographql.apollo.api.internal.Optional;

--- a/sample/src/xApollo/java/com/shopify/sample/domain/repository/ShopRepository.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/repository/ShopRepository.java
@@ -1,6 +1,6 @@
 package com.shopify.sample.domain.repository;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.apollographql.apollo.ApolloClient;
 import com.apollographql.apollo.api.internal.Optional;

--- a/sample/src/xApollo/java/com/shopify/sample/domain/usecases/FetchCollectionsUseCaseImpl.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/usecases/FetchCollectionsUseCaseImpl.java
@@ -1,8 +1,8 @@
 package com.shopify.sample.domain.usecases;
 
 import android.os.Handler;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloClient;

--- a/sample/src/xApollo/java/com/shopify/sample/domain/usecases/FetchProductsUseCaseImpl.java
+++ b/sample/src/xApollo/java/com/shopify/sample/domain/usecases/FetchProductsUseCaseImpl.java
@@ -1,8 +1,8 @@
 package com.shopify.sample.domain.usecases;
 
 import android.os.Handler;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloClient;


### PR DESCRIPTION
- It compiles and runs successfully.
- In the CheckoutActivity, had to manually point to the R.id.snackbar_text instead of the id from the legacy support library.
- The new Butterknife requires the @BindView annotation to use R2 as mentioned in their repo instructions: https://github.com/JakeWharton/butterknife
- Had to manually replace import android.support.annotation.NonNull with import androidx.annotation.NonNull.